### PR TITLE
2Dキャラ描画順を変更

### DIFF
--- a/MS_Project/Assets/Scripts/Shaders/S_SpriteShadow.shader
+++ b/MS_Project/Assets/Scripts/Shaders/S_SpriteShadow.shader
@@ -20,7 +20,7 @@ Shader "Custom/SpriteShadow"
     {
         Tags
         {
-            "Queue" = "Transparent"
+            "Queue" = "Overlay"
             "IgnoreProjector" = "True"
             "RenderType" = "Transparent"
             "PreviewType" = "Plane"
@@ -29,6 +29,7 @@ Shader "Custom/SpriteShadow"
  
         Cull Off
         Lighting On
+		ZTest Always
         ZWrite Off
         Blend One OneMinusSrcAlpha
  


### PR DESCRIPTION
### 2Dキャラ描画順を変更
* 2Dキャラを必ず他オブジェクトの前に描画するため、`Overlay`に設定