### PR TITLE
エネミー死亡処理を修正

### DIFF
--- a/MS_Project/Assets/Scripts/Character/WorldObjects/EnemyController.cs
+++ b/MS_Project/Assets/Scripts/Character/WorldObjects/EnemyController.cs
@@ -25,12 +25,16 @@ public class EnemyController : ObjectController, IHit
     private CapsuleCollider capsuleCollider;
     protected Rigidbody rb;
 
+    private GameObject spawnPool;
+
     public override void Awake()
     {
         base.Awake();
 
         capsuleCollider = this.GetComponent<CapsuleCollider>();
         rb = this.GetComponent<Rigidbody>();
+
+        spawnPool = GameObject.FindGameObjectWithTag("EnemyCollector").gameObject;
     }
 
     public override void Start()
@@ -173,7 +177,12 @@ public class EnemyController : ObjectController, IHit
             player.GetComponent<PlayerController>().StatusManager.TakeDamage(-5);
 
             //殺す
-            //Destroy(this.gameObject);
+            spawnPool.GetComponent<EnemySpawner>().DespawnEnemy(this.gameObject);
+        }
+
+        if (status.Health <= 0)
+        {
+            spawnPool.GetComponent<EnemySpawner>().DespawnEnemy(this.gameObject);
         }
     }
 

--- a/MS_Project/Assets/Scripts/Onomatopoeia/OnomatopoeiaController.cs
+++ b/MS_Project/Assets/Scripts/Onomatopoeia/OnomatopoeiaController.cs
@@ -41,7 +41,7 @@ public class OnomatopoeiaController : MonoBehaviour
         onomatoManager = this.gameObject.GetComponent<OnomatoManager>();
 
         objOnomatopoeia = this.gameObject;
-        objOnomatopoeia.transform.rotation = new Quaternion(0, 0, -90, 0);
+        //objOnomatopoeia.transform.rotation = new Quaternion(0, 0, -90, 0);
     }
 
     // Start is called before the first frame update


### PR DESCRIPTION
### エネミー死亡処理を修正
* `Pool`から削除してから、`GameObject`（自分）を削除
* オノマトペの回転を修正