### PR TITLE
Fix: 敵死亡時animatorのnullチェック

### DIFF
--- a/MS_Project/Assets/Scripts/Manager/BattleManager.cs
+++ b/MS_Project/Assets/Scripts/Manager/BattleManager.cs
@@ -43,7 +43,7 @@ public class BattleManager : SingletonBaseBehavior<BattleManager>
         yield return new WaitForSeconds(_duration);
 
         // 流す速度を戻す
-        _animator.speed = 1f;
+        if (_animator != null) _animator.speed = 1f;
     }
 
     public HitReaction GetPlayerHitReaction()


### PR DESCRIPTION
Fix: 敵死亡時animatorのnullチェック