### PR TITLE
シーン遷移調整

### DIFF
--- a/MS_Project/Assets/Plugins.meta
+++ b/MS_Project/Assets/Plugins.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0d096e13fc84a12419d4100ab560b225
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MS_Project/Assets/Plugins/Demigiant.meta
+++ b/MS_Project/Assets/Plugins/Demigiant.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8a7cf55bba750494986ca2d23194cac0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MS_Project/Assets/Plugins/Demigiant/DOTween.meta
+++ b/MS_Project/Assets/Plugins/Demigiant/DOTween.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e5c5ac1415f3976438dfbc40506ce707
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MS_Project/Assets/Plugins/Demigiant/DOTween/Editor.meta
+++ b/MS_Project/Assets/Plugins/Demigiant/DOTween/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dd7c84565917b044395fd35757eb9e6a
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/MS_Project/Assets/Scenes/Result.prefab
+++ b/MS_Project/Assets/Scenes/Result.prefab
@@ -692,7 +692,7 @@ MonoBehaviour:
   fadePanel: {fileID: 5440288845280359137}
   fadeDuration: 1
   buttonObject: {fileID: 7967686111696194255}
-  sceneToLoad: StageSelect
+  sceneToLoad: Title
 --- !u!1 &8415111116406616854
 GameObject:
   m_ObjectHideFlags: 0

--- a/MS_Project/Assets/Scenes/Title.unity
+++ b/MS_Project/Assets/Scenes/Title.unity
@@ -612,7 +612,7 @@ MonoBehaviour:
   fadePanel: {fileID: 1137834016}
   fadeDuration: 1
   buttonObject: {fileID: 808694724}
-  sceneToLoad: StageSelect
+  sceneToLoad: StartScene01
 --- !u!114 &808694727
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
エリアセレクトに飛ばないよう調整。
タイトルから直接ステージに遷移します。
リザルトではエリアセレクトに戻る遷移をタイトル画面に遷移するよう変更しました。